### PR TITLE
📚 update run locally instructions

### DIFF
--- a/markets/perps-market/run-locally-instructions.md
+++ b/markets/perps-market/run-locally-instructions.md
@@ -5,6 +5,7 @@ This document provides a brief set up of instructions for devs to run the quanto
 ## Developer Pre-requisites
 
 You need the following tools installed:
+
 - Yarn
 - Foundry
 - Cannon
@@ -12,15 +13,19 @@ You need the following tools installed:
 ### Foundry Installation
 
 1. Install foundry see - https://github.com/foundry-rs/foundry, https://book.getfoundry.sh/getting-started/installation - or simply follow below instructions:
+
 ```bash
 curl -L https://foundry.paradigm.xyz | bash
 # restart terminal
 foundryup
 ```
+
 2. Test foundry is working by running `anvil`
+
 ```bash
 anvil
 ```
+
 This should boot up a local test ethereum node. If successful exit the process with `cntrl+c`.
 
 ### Cannon Installation
@@ -32,24 +37,41 @@ npm install -g @usecannon/cli
 ## Developer Get Started
 
 1. Clone this repo:
+
 ```bash
 git clone git@github.com:Kwenta/synthetix-v3.git
 ```
+
 2. Checkout the `dev` branch
+
 ```bash
 git checkout dev
 ```
+
 3. Run `yarn` at the root directory: `/synthetix-v3`.
 4. Run `yarn compile-contracts` at the root directory: `/synthetix-v3`.
+
+   4.1 In case you get the following error :
+
+   ```bash
+   Error: Cannot find module '/synthetix-v3/node_modules/@synthetixio/hardhat-storage/dist/index.js'.
+   ```
+
+   - Run `yarn build` at the `/synthetix-v3/utils/core-utils/` directory.
+   - Run `yarn build` at the `/synthetix-v3/utils/hardhat-storage/` directory.
+   - Run `yarn` at the root directory: `/synthetix-v3`.
+
 5. Run `yarn generate-testable` at the root directory: `/synthetix-v3`.
 6. Run `yarn build-testable` at the root directory: `/synthetix-v3`.
 7. Jump into the `perps-market` directory: `cd markets/perps-market`
 8. Run `yarn build-testable`
 9. Launch a local node with the test build:
+
 ```bash
 # The exact version may change from 3.3.15 - check your terminal output from yarn build-testable for the latest
 cannon synthetix-perps-market:3.3.15-testable@main
 ```
+
 10. Press `i` to interact with contracts via the command line.
 11. Scroll down to `PerpsMarketProxy` and hit `enter`
 12. View proxy address: `PerpsMarketProxy => 0xSomeAddress...ADF989`


### PR DESCRIPTION
## Description

Update the `markets/perps-market/run-locally-instructions.md` instructions with how to handle `Cannot find module` Errors when setting up the project for the first time.